### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/SKB-CGN/ioBroker.energiefluss-erweitert.git"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3"


### PR DESCRIPTION
adapter-core 3.x.x is known to fail during installation on node 14 as npm 6 does not install peerDependencies.
So this adapter requires node 16 or higher